### PR TITLE
Dropped support for Ubuntu versions before Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ Requirements
 
 * Ubuntu
 
-    * Trusty (14.04)
-    * Wily (15.10)
     * Xenial (16.04)
-    * Note: other Ubuntu versions are likely to work but have not been tested.
 
 * Supported desktop
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,8 +7,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
-        - wily
         - xenial
   galaxy_tags:
     - ubuntu


### PR DESCRIPTION
These aren't part of the automated tests.