### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: xsession.yml
+- import_tasks: xsession.yml
 
-- include: gnome.yml
+- import_tasks: gnome.yml
 
-- include: xfce4.yml
+- import_tasks: xfce4.yml


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```