### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_gnome.py
+++ b/molecule/default/tests/test_gnome.py
@@ -7,8 +7,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_mimeapps_file_permissions(File):
-    config = File('/etc/xdg/ansible-default-web-browser/mimeapps.list')
+def test_mimeapps_file_permissions(host):
+    config = host.file('/etc/xdg/ansible-default-web-browser/mimeapps.list')
 
     assert config.exists
     assert config.is_file
@@ -24,8 +24,8 @@ def test_mimeapps_file_permissions(File):
     'x-scheme-handler/about=google-chrome.desktop',
     'x-scheme-handler/unknown=google-chrome.desktop'
 ])
-def test_mimeapps_file(File, expected):
-    config = File('/etc/xdg/ansible-default-web-browser/mimeapps.list')
+def test_mimeapps_file(host, expected):
+    config = host.file('/etc/xdg/ansible-default-web-browser/mimeapps.list')
 
     assert config.exists
     assert config.is_file

--- a/molecule/default/tests/test_xfce4.py
+++ b/molecule/default/tests/test_xfce4.py
@@ -7,8 +7,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_helpers_file_permissions(File):
-    config = File('/etc/xdg/ansible-default-web-browser/xfce4/helpers.rc')
+def test_helpers_file_permissions(host):
+    config = host.file('/etc/xdg/ansible-default-web-browser/xfce4/helpers.rc')
 
     assert config.exists
     assert config.is_file
@@ -18,9 +18,9 @@ def test_helpers_file_permissions(File):
     assert config.contains('WebBrowser=google-chrome')
 
 
-def test_desktop_file_permissions(File):
+def test_desktop_file_permissions(host):
     helper_dir = '/etc/xdg/ansible-default-web-browser/xfce4/helpers'
-    desktop = File(helper_dir + '/google-chrome.desktop')
+    desktop = host.file(helper_dir + '/google-chrome.desktop')
 
     assert desktop.exists
     assert desktop.is_file
@@ -35,9 +35,9 @@ def test_desktop_file_permissions(File):
     'X-XFCE-Commands=/usr/bin/google-chrome-stable',
     'X-XFCE-CommandsWithParameter=/usr/bin/google-chrome-stable "%s"'
 ])
-def test_desktop_file(File, expected):
+def test_desktop_file(host, expected):
     helper_dir = '/etc/xdg/ansible-default-web-browser/xfce4/helpers'
-    desktop = File(helper_dir + '/google-chrome.desktop')
+    desktop = host.file(helper_dir + '/google-chrome.desktop')
 
     assert desktop.exists
     assert desktop.is_file

--- a/molecule/default/tests/test_xsession.py
+++ b/molecule/default/tests/test_xsession.py
@@ -7,8 +7,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_xsession_file_permissions(File):
-    config = File('/etc/X11/Xsession.d/80-ansible-default-web-browser')
+def test_xsession_file_permissions(host):
+    config = host.file('/etc/X11/Xsession.d/80-ansible-default-web-browser')
 
     assert config.exists
     assert config.is_file
@@ -21,8 +21,8 @@ def test_xsession_file_permissions(File):
     'XDG_CONFIG_DIRS=/etc/xdg/ansible-default-web-browser:"$XDG_CONFIG_DIRS"',
     'XDG_DATA_DIRS=/etc/xdg/ansible-default-web-browser:"$XDG_DATA_DIRS"'
 ])
-def test_xsession_file(File, expected):
-    config = File('/etc/X11/Xsession.d/80-ansible-default-web-browser')
+def test_xsession_file(host, expected):
+    config = host.file('/etc/X11/Xsession.d/80-ansible-default-web-browser')
 
     assert config.exists
     assert config.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.